### PR TITLE
fix: add homepage link to navbar title

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Shinobi",
@@ -16,9 +17,11 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <header className="flex justify-between items-center p-4 bg-surface border-b border-border">
-          <h1 className="text-3xl font-semibold m-0 text-foreground">
-            Shinobi
-          </h1>
+          <Link href="/">
+            <h1 className="text-3xl font-semibold m-0 text-foreground cursor-pointer hover:opacity-80 transition-opacity">
+              Shinobi
+            </h1>
+          </Link>
           <DarkModeToggle />
         </header>
         {children}


### PR DESCRIPTION
Fixes the missing homepage link from the navbar title.

## Changes
- Wrapped the "Shinobi" title in the navbar with a Next.js Link component
- Link points to the homepage route (/)
- Added hover effect for better UX

Closes #2

Generated with [Claude Code](https://claude.ai/code)